### PR TITLE
Citadel support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         rosdep init
         rosdep update
         rosdep install --from-paths ./ -i -y --rosdistro foxy \
-          --ignore-src --skip-keys "ignition-gazebo5 ignition-plugin1"
+          --ignore-src --skip-keys "ignition-gazebo5"
     - name: Build project
       id: build
       run: |

--- a/Dockerfile/Dockerfile
+++ b/Dockerfile/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir -p /home/ros2_ws/src \
     && git clone https://github.com/ignitionrobotics/ign_ros2_control/ -b ahcorde/ign_ros2_control \
     && rosdep update \
     && rosdep install --from-paths ./ -i -y --rosdistro foxy \
-      --ignore-src --skip-keys "ignition-gazebo5 ignition-plugin1"
+      --ignore-src --skip-keys "ignition-gazebo5"
 
 RUN cd /home/ros2_ws/ \
   && . /opt/ros/foxy/setup.sh \

--- a/ignition_ros2_control/package.xml
+++ b/ignition_ros2_control/package.xml
@@ -12,7 +12,7 @@
   <depend>ament_index_cpp</depend>
   <depend condition="$IGNITION_VERSION == cidadel">ignition-gazebo3</depend>
   <depend condition="$IGNITION_VERSION == edifice">ignition-gazebo5</depend>
-  <depend>ignition-plugin1</depend>
+  <depend>ignition-plugin</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>yaml_cpp_vendor</depend>

--- a/ignition_ros2_control/src/ignition_ros2_control_plugin.cpp
+++ b/ignition_ros2_control/src/ignition_ros2_control_plugin.cpp
@@ -405,7 +405,7 @@ void IgnitionROS2ControlPlugin::Configure(
 
 //////////////////////////////////////////////////
 void IgnitionROS2ControlPlugin::PreUpdate(
-  const ignition::gazebo::UpdateInfo &_info,
+  const ignition::gazebo::UpdateInfo & _info,
   ignition::gazebo::EntityComponentManager & /*_ecm*/)
 {
   static bool warned{false};

--- a/ignition_ros2_control/src/ignition_ros2_control_plugin.cpp
+++ b/ignition_ros2_control/src/ignition_ros2_control_plugin.cpp
@@ -408,21 +408,26 @@ void IgnitionROS2ControlPlugin::PreUpdate(
   const ignition::gazebo::UpdateInfo &_info,
   ignition::gazebo::EntityComponentManager & /*_ecm*/)
 {
-  rclcpp::Duration gazebo_period(_info.dt);
+  static bool warned{false};
+  if (!warned)
+  {
+    rclcpp::Duration gazebo_period(_info.dt);
 
-  // Check the period against the simulation period
-  if (this->dataPtr->control_period_ < _info.dt) {
-    RCLCPP_ERROR_STREAM(
-      this->dataPtr->node->get_logger(),
-      "Desired controller update period (" << this->dataPtr->control_period_.seconds() <<
-        " s) is faster than the gazebo simulation period (" <<
-        gazebo_period.seconds() << " s).");
-  } else if (this->dataPtr->control_period_ > gazebo_period) {
-    RCLCPP_WARN_STREAM(
-      this->dataPtr->node->get_logger(),
-      " Desired controller update period (" << this->dataPtr->control_period_.seconds() <<
-        " s) is slower than the gazebo simulation period (" <<
-        gazebo_period.seconds() << " s).");
+    // Check the period against the simulation period
+    if (this->dataPtr->control_period_ < _info.dt) {
+      RCLCPP_ERROR_STREAM(
+        this->dataPtr->node->get_logger(),
+        "Desired controller update period (" << this->dataPtr->control_period_.seconds() <<
+          " s) is faster than the gazebo simulation period (" <<
+          gazebo_period.seconds() << " s).");
+    } else if (this->dataPtr->control_period_ > gazebo_period) {
+      RCLCPP_WARN_STREAM(
+        this->dataPtr->node->get_logger(),
+        " Desired controller update period (" << this->dataPtr->control_period_.seconds() <<
+          " s) is slower than the gazebo simulation period (" <<
+          gazebo_period.seconds() << " s).");
+    }
+    warned = true;
   }
 
   // Always set commands on joints, otherwise at low control frequencies the joints tremble

--- a/ignition_ros2_control/src/ignition_ros2_control_plugin.cpp
+++ b/ignition_ros2_control/src/ignition_ros2_control_plugin.cpp
@@ -409,8 +409,7 @@ void IgnitionROS2ControlPlugin::PreUpdate(
   ignition::gazebo::EntityComponentManager & /*_ecm*/)
 {
   static bool warned{false};
-  if (!warned)
-  {
+  if (!warned) {
     rclcpp::Duration gazebo_period(_info.dt);
 
     // Check the period against the simulation period

--- a/ignition_ros2_control_demos/launch/cart_example_position.launch.py
+++ b/ignition_ros2_control_demos/launch/cart_example_position.launch.py
@@ -79,18 +79,18 @@ def generate_launch_description():
                 [os.path.join(get_package_share_directory('ros_ign_gazebo'),
                               'launch', 'ign_gazebo.launch.py')]),
             launch_arguments=[('ign_args', [' -r -v 3 empty.sdf'])]),
-        #RegisterEventHandler(
-        #    event_handler=OnProcessExit(
-        #        target_action=ignition_spawn_entity,
-        #        on_exit=[load_joint_state_controller],
-        #    )
-        #),
-        #RegisterEventHandler(
-        #    event_handler=OnProcessExit(
-        #        target_action=load_joint_state_controller,
-        #        on_exit=[load_joint_trajectory_controller],
-        #    )
-        #),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=ignition_spawn_entity,
+                on_exit=[load_joint_state_controller],
+            )
+        ),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=load_joint_state_controller,
+                on_exit=[load_joint_trajectory_controller],
+            )
+        ),
         node_robot_state_publisher,
         ignition_spawn_entity,
         # Launch Arguments

--- a/ignition_ros2_control_demos/launch/cart_example_position.launch.py
+++ b/ignition_ros2_control_demos/launch/cart_example_position.launch.py
@@ -79,18 +79,18 @@ def generate_launch_description():
                 [os.path.join(get_package_share_directory('ros_ign_gazebo'),
                               'launch', 'ign_gazebo.launch.py')]),
             launch_arguments=[('ign_args', [' -r -v 3 empty.sdf'])]),
-        RegisterEventHandler(
-            event_handler=OnProcessExit(
-                target_action=ignition_spawn_entity,
-                on_exit=[load_joint_state_controller],
-            )
-        ),
-        RegisterEventHandler(
-            event_handler=OnProcessExit(
-                target_action=load_joint_state_controller,
-                on_exit=[load_joint_trajectory_controller],
-            )
-        ),
+        #RegisterEventHandler(
+        #    event_handler=OnProcessExit(
+        #        target_action=ignition_spawn_entity,
+        #        on_exit=[load_joint_state_controller],
+        #    )
+        #),
+        #RegisterEventHandler(
+        #    event_handler=OnProcessExit(
+        #        target_action=load_joint_state_controller,
+        #        on_exit=[load_joint_trajectory_controller],
+        #    )
+        #),
         node_robot_state_publisher,
         ignition_spawn_entity,
         # Launch Arguments


### PR DESCRIPTION
* Fixed `ignition-plugin` rosdep key
* Checking the update rate from `UpdateInfo`, so we're not relying on an Edifice feature

I got as far as building against Citadel using `ros-foxy-ros-ign`. But it crashes at runtime when `ClassLoader` tries to load `IgnitionSystemInterface`. That's how far I got.

I wasn't able to run the Edifice version. The Docker instructions hang for me, as well as building locally. I'm not sure how that would work. because `ros-foxy-ros-ign` is compiled against Citadel, and the Docker image builds against Edifice. Does it work for you @ahcorde ?