### PR TITLE
Fix ignition version in package.xml

### DIFF
--- a/ign_ros2_control/package.xml
+++ b/ign_ros2_control/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>ament_index_cpp</depend>
+  <!-- default version to use in official ROS2 packages is Ignition Edifice for ROS2 Galactic -->
   <depend condition="$IGNITION_VERSION == ''">ignition-gazebo5</depend>
   <depend condition="$IGNITION_VERSION == cidadel">ignition-gazebo3</depend>
   <depend condition="$IGNITION_VERSION == edifice">ignition-gazebo5</depend>

--- a/ign_ros2_control/package.xml
+++ b/ign_ros2_control/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>ament_index_cpp</depend>
-  <depend condition="$IGNITION_VERSION == ''">ignition-gazebo3</depend>
+  <depend condition="$IGNITION_VERSION == ''">ignition-gazebo5</depend>
   <depend condition="$IGNITION_VERSION == cidadel">ignition-gazebo3</depend>
   <depend condition="$IGNITION_VERSION == edifice">ignition-gazebo5</depend>
   <depend condition="$IGNITION_VERSION == fortress">ignition-gazebo6</depend>


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

Fixed the default ignition-gazebo version in Edifice

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

