### PR TITLE
ros2_control is now having usings under its namespace.

### DIFF
--- a/ign_ros2_control/include/ign_ros2_control/ign_system.hpp
+++ b/ign_ros2_control/include/ign_ros2_control/ign_system.hpp
@@ -27,6 +27,8 @@
 
 namespace ign_ros2_control
 {
+using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
 // Forward declaration
 class IgnitionSystemPrivate;
 


### PR DESCRIPTION
Check ros-controls/ros2_control#673 for more info. This breaks build of the plugin.
