### PR TITLE
Do not hardcode distro in entrypoint.sh

### DIFF
--- a/Dockerfile/entrypoint.sh
+++ b/Dockerfile/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-. /opt/ros/foxy/setup.sh
+. /opt/ros/"${ROS_DISTRO}"/setup.sh
 . /home/ros2_ws/install/setup.sh
 exec "$@"


### PR DESCRIPTION
Signed-off-by: Rufus Wong <rcywongaa@gmail.com>

## Summary
Fixes
```
/entrypoint.sh: 3: .: Can't open /opt/ros/foxy/setup.sh
```
when running on `galactic` branch with ROS Galactic

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
